### PR TITLE
Update Lab_18_EnableSignRiskPolicy.md

### DIFF
--- a/Instructions/Labs/Lab_18_EnableSignRiskPolicy.md
+++ b/Instructions/Labs/Lab_18_EnableSignRiskPolicy.md
@@ -57,7 +57,7 @@ As an additional layer of security, you need to enable and configure your Azure 
 
 1. In the Sign-in risk pane, select **High** and then select **Done**.
 
-1. Under **Controls** > **Access**, select **Block access**.
+1. Under **Controls** > **Access**, select **Allow access**.
 
 1. Select the **Require multi-factor authentication** check box and then select **Done**.
 


### PR DESCRIPTION
You cannot set the access to block and enable MFA at the same time. I think this has meant to be allowed

# Module: 02
## Lab/Demo: 18

Fixes #46

Changes proposed in this pull request:

- Set the grant to allow to be able to justify enabling MFA in the next task
