### PR TITLE
Update lab 6 to specify the Finance Team group

### DIFF
--- a/Instructions/Labs/Lab_06_ChangeGroupLicenseAssignments.md
+++ b/Instructions/Labs/Lab_06_ChangeGroupLicenseAssignments.md
@@ -19,7 +19,7 @@ Occasionally, you may need to change the license assignment that are used by an 
 
 1. In the left navigation, under **Manage**, select **Groups**.
 
-1. Select one of the available groups. For example, Sales and Marketing.
+1. Select the **Finance Team** group.
 
 1. In the left navigation, under **Manage**, select **Licenses**.
 


### PR DESCRIPTION
This lab needs to specify a group that contains less than 20 members or the license assignment in lab 7 will fail due to no licenses being available.

# Module: 00
## Lab/Demo: 00

Fixes # .

Changes proposed in this pull request:

-
-
-