### PR TITLE
Update Lab_06_ChangeGroupLicenseAssignments.md

### DIFF
--- a/Instructions/Labs/Lab_06_ChangeGroupLicenseAssignments.md
+++ b/Instructions/Labs/Lab_06_ChangeGroupLicenseAssignments.md
@@ -21,7 +21,7 @@ Occasionally, you may need to change the license assignment that are used by an 
 
 2. In the left navigation, under **Manage**, select **Groups**.
 
-3. Select the **Finance Team** group.
+3. Select the **sg-Sales and Marketing** group.
 
 4. In the left navigation, under **Manage**, select **Licenses**.
 


### PR DESCRIPTION
The finance Team is a Distribution Group. You can only assign licenses to M365 or security groups.
Using sg-Sales and Marketing will also work out better for lab 7, because if you pick a group with 20 members, all licenses will be used, and you are stuck in the next lab (need to assign license to a single user)

# Module: 01
## Lab/Demo: 06

Fixes # .

Changes proposed in this pull request:

- Replace Finance team for sg-Sales and Marketing
-
-