### PR TITLE
Update Lab_16_UsingAzureKeyVaultForManagedIdentities.md

### DIFF
--- a/Instructions/Labs/Lab_16_UsingAzureKeyVaultForManagedIdentities.md
+++ b/Instructions/Labs/Lab_16_UsingAzureKeyVaultForManagedIdentities.md
@@ -52,7 +52,7 @@ When you use managed identities for Azure resources, your code can get access to
 
  - **Resource group** - sc300KeyVaultrg
  - **Key vault name** - *anyuniquevalue*
-
+ - On the **Access Configuration** page, select the **Vault Access Policy** radio button.
 1. Select **Review + create**.
 
 1. Select **Create**.


### PR DESCRIPTION
Just keyed this lab. MS now uses RBAC as the default for permission assignment to create secrets.  Lab step added to address the need to switch to Vault Access Policy for the rest of the lab to work.

# Module: 00
## Lab/Demo: 00

Fixes # .

Changes proposed in this pull request:

-
-
-