### PR TITLE
Update Lab_01_ManageUserRoles.md

### DIFF
--- a/Instructions/Labs/Lab_01_ManageUserRoles.md
+++ b/Instructions/Labs/Lab_01_ManageUserRoles.md
@@ -209,7 +209,7 @@ After the users have been created, you will be prompted that the creation has su
         -DisplayName "New PW User" `
         -GivenName "New" -Surname "User" `
         -MailNickname "newuser" `
-        -UsageLocation "USA" `
+        -UsageLocation "US" `
         -UserPrincipalName "newuser@<labtenantname.com>" `
         -PasswordProfile $PWProfile -AccountEnabled `
         -Department "Research" -JobTitle "Trainer"


### PR DESCRIPTION
# Module: 01
## Lab/Demo: 01 - Exercise 4 Task 2

Fixes # .The MG-User parameter "UsageLocation" only accepts 2-character country codes, where the instructions has "USA" which is not recognized as valid.

Changes proposed in this pull request:

- change USA to US in UsageLocation
-
-