### PR TITLE
Fix retired VM sizes, stale resource group reference, step ordering, and host-specific wording

### DIFF
--- a/Instructions/Labs/Lab_01_ManageUserRoles.md
+++ b/Instructions/Labs/Lab_01_ManageUserRoles.md
@@ -38,7 +38,7 @@ Your company recently hired a new employee who will perform duties as an applica
 
 #### Task 1 - Add a new user
 
-1. Open Microsoft Edge and navigate to the **Microsoft Entra admin center** at **`https://entra.microsoft.com`**. Sign in using a Global Administrator account provided by your authorized lab hoster (ALH).
+1. Open Microsoft Edge and navigate to the **Microsoft Entra admin center** at **`https://entra.microsoft.com`**. Sign in using the Global Administrator account provided for this lab.
 
     > **Note:** You may be prompted to complete Multi-Factor Authentication (MFA) during sign-in. Follow the prompts to configure or verify your authentication method before continuing.
 
@@ -197,15 +197,17 @@ In this exercise, you removed the Application Administrator role from the user t
 
 1. Select **Download** to download the **.csv** file.
 
-1. The .csv template provides you with the fields included with the user profile. This includes the required username, display name, and initial password. You can also complete optional fields, such as Department and Usage location, at this time. The following screenshot is an example of how you can complete the .csvfile: 
+    > **Note:** A ready-to-use sample CSV file is already provided in the **Allfiles/Labs/Lab1** folder — **SC300BulkUser.csv**. Use this file instead of manually filling out the downloaded template. Open it in **Notepad** (not Excel), update the domain name, and save it before continuing to the next step.
+
+1. The .csv template provides you with the fields included with the user profile. This includes the required username, display name, and initial password. You can also complete optional fields, such as Department and Usage location, at this time. The following screenshot is an example of how you can complete the .csv file, shown for reference only:
 
     ![Bulk import using csv file entry](./media/bulkimportexample.png)
 
-    You can modify this file to add users in bulk.  Note that you do not need to fill out all the fields.  As per the sample data provide, you mainly need to add the name and username information.
+    You do not need to fill out all the fields.  As per the sample data provided, you mainly need to add the name and username information.
 
-1. A sample CSV has been provided in the Allfiles/Labs/Lab1 folder -- **SC300BulkUser.csv**.
+1. To prepare the provided sample file:
    1. Open Notepad: inside the lab environment, select the **Start** button and type **Notepad**.  
-   1. Open the SC300BulkUser.csv file
+   1. Open the **SC300BulkUser.csv** file from the **Allfiles/Labs/Lab1** folder.
    1. Change the **enter your domain name** to the domain of your Azure lab environment.
    1. Save the file.
 

--- a/Instructions/Labs/Lab_07_AddHybridIdentityWithAzureADConnect.md
+++ b/Instructions/Labs/Lab_07_AddHybridIdentityWithAzureADConnect.md
@@ -13,7 +13,7 @@ lab:
 
 # Lab 07: OPTIONAL - Add Hybrid Identity with Microsoft Entra Connect
 
-# This lab will only function in a non-lab-hoster environment. If you want to try it using a personal account, it should work. You will not be able to perform within the class.
+> **Note:** This lab provisions a separate on-premises Active Directory environment and requires subscription-level permissions that may not be available in the environment provided for this course. If you have access to a personal Azure subscription, you can complete this lab there; you may not be able to complete every step in the environment provided for this class.
 
 **Note** - This lab is titled Optional.  It takes at least 1 hour to complete and does require that you are detailed in your lab steps.  Please feel free to complete it as time permits.  If your company has already set up its Hybrid configuration, or you don't plan to use Microsoft Entra Connect, please jump over this lab.
 
@@ -51,7 +51,7 @@ Your company works has Active Directory Domain Services on-premises.  They would
    -   Admin Password: **Enter a secure password that you will remember**
    -   Deploy Client VM: **No**
    -   Client VHD URI: **leave blank**
-   -   VM Size: **Standard_D2s_v3**
+   -   VM Size: **Standard_D2s_v5**
    
     >**Note:** Use a similar VM size if your subscription does not support the listed size. Documentation is linked here: `https://docs.microsoft.com/en-us/azure/virtual-machines/windows/sizes`.
 

--- a/Instructions/Labs/Lab_10_AzureADAuthenticationForWindowsAndLinuxVM.md
+++ b/Instructions/Labs/Lab_10_AzureADAuthenticationForWindowsAndLinuxVM.md
@@ -42,12 +42,12 @@ The company has decided that Microsoft Entra ID should be used to login to virtu
   | Field | Value to use |
   | :-- | :-- |
   | Subscription | Accept the default |
-  | Resource Group | Select **rgEL** |
+  | Resource Group | Select or create a new resource group for this lab |
   | Virtual machine name | **vmEntraLogin** |
   | Region | *default* |
   | Availability options | **No infrastructure redundancy required** |
   | Security Type | **Standard** |
-  | Size | **Standard DC1s_v3 - 1 vcpu, 8 GiB memory** |
+  | Size | **Standard D2s_v5 - 2 vcpus, 8 GiB memory** |
   | | **Lab tip** - if the exact specified size is not available, try a similar size in the same series.|
   | Admin Username | **vmEntraAdmin** |
   | Admin Password | Use the one provided by the lab environment or make us a secure password you can remember |

--- a/Instructions/Labs/Lab_23_AddTermsOfUseAcceptanceReporting.md
+++ b/Instructions/Labs/Lab_23_AddTermsOfUseAcceptanceReporting.md
@@ -148,7 +148,7 @@ Once you have finalized your terms of use document, use the following procedure 
     | Setting | Value to enter |
     | :--- | :--- |
     | User Name | `AdeleV@<your domain name>.onmicrosoft.com` |
-    | Password | Enter the tenant's admin password(Refer the Lab Resources tab to retrieve the tenant admin password) |
+    | Password | Enter the tenant admin password provided for this lab |
 
 1. Validate Adele's login with the MFA request.
 

--- a/Instructions/Labs/Lab_27_MicrosoftSentinelKustoQueries.md
+++ b/Instructions/Labs/Lab_27_MicrosoftSentinelKustoQueries.md
@@ -17,7 +17,7 @@ lab:
 
 In this lab, you explore Microsoft Sentinel by working with Microsoft Entra ID data sources and running hunting queries using Kusto Query Language (KQL). You review how to connect data sources, create a Microsoft Sentinel workspace, and execute queries as part of security operations tasks.
 
- >**Note:** This lab cannot be completed in the provided training lab environment at this time. We are leaving the lab step here, so you can optionally try it on your Bring You Own Subscription (BYOS) environment.  Please read over the steps to see what is possible. We are actively working this lab to find a work-around in the lab environment, and will update it soon.
+ >**Note:** This lab cannot be completed in the provided training lab environment at this time. We are leaving the lab step here so you can optionally try it using a personal Azure subscription. Please read over the steps to see what is possible. We are actively working this lab to find a work-around in the lab environment, and will update it soon.
 
 ### Login type: Azure resource login
 
@@ -68,6 +68,8 @@ Microsoft Sentinel is Microsoft's cloud-native SIEM and SOAR solution.  Through 
     >**Note:** You should show 1 Connector installed and see **Microsoft Entra ID** listed.
 
 1. Select **Microsoft Entra ID** and then select **Open connector page**.
+
+    > **Note:** Connecting this data source requires Global Administrator or Security Administrator permissions, plus permission to configure diagnostic settings on the tenant. If the account used for this lab doesn't have these permissions, the **Prerequisites** checklist on the connector page will show missing items and you won't be able to complete steps 6-10. Review the remaining steps to understand the intended workflow, then continue on with Task 3.
 
 1. In the connector page, the instructions and next steps will be provided for the data connector. Verify that a check-mark is next to each of the **Prerequisites** to continue with the **Configuration**.
 


### PR DESCRIPTION
﻿## Summary
This PR fixes several learner-facing problems reported across Lab 01, Lab 07, Lab 10, Lab 23, and Lab 27: retired VM sizes that fail to deploy, a resource group name that no longer exists in the lab environment, confusing step ordering in a bulk-user-import task, and wording that refers to lab-hosting-platform concepts (which should never appear in learner-facing instructions, since these labs are delivered on multiple hosting platforms).

## Learner/instructor impact
- Lab 07 and Lab 10 told learners to deploy a `Standard_D2s_v3` / `Standard DC1s_v3` sized VM. That size series has been phased out in many regions, so the deployment step fails and blocks the rest of the lab (#252).
- Lab 10 told learners to select a resource group named `rgEL`, which does not exist in the provisioned environment, leaving learners stuck at VM creation (#222).
- Lab 01's bulk-user-import task led learners to open the downloaded CSV template in Excel and try to hand-fill it, when a ready-to-use sample file was already provided later in the same task — causing avoidable confusion and wasted time (#189).
- Lab 27's Microsoft Sentinel data-connector task could fail partway through (steps 6-10) if the signed-in account lacks Global Administrator/Security Administrator and diagnostic-settings permissions, with no warning before the learner reaches that point (#221).
- Lab 01, 07, 23, and 27 referred to hosting-platform-specific concepts (an "authorized lab hoster (ALH)," a "Lab Resources tab," "Bring Your Own Subscription (BYOS)," and a "non-lab-hoster environment"). Since this course is delivered through more than one lab-hosting platform, and these terms are meaningless or actively confusing outside a specific host's UI, they should never appear in learner-facing steps.

## What changed and why
- Replaced the retired VM size in Lab 07 and Lab 10 with `Standard_D2s_v5`, the current-generation equivalent, so the VM deployment steps succeed.
- Replaced the hard-coded `rgEL` resource group name in Lab 10 with generic guidance to select or create a resource group for the lab, since the exact name depends on what the environment provisions.
- Reordered Lab 01's bulk-import task so the note about the ready-to-use sample CSV (and the instruction to edit it in Notepad, not Excel) appears immediately after the download step, before the Excel-oriented template walkthrough.
- Added an inline note in Lab 27, Task 2 explaining the permission prerequisites for the Sentinel data connector before the learner reaches the step that can fail, so the limitation is clear in context instead of only being disclosed after the fact.
- Reworded the host-specific references in Lab 01, 07, 23, and 27 to describe what the learner needs (a provided account, a provided password, a personal subscription) without naming any specific lab-hosting platform or UI element.

## Validation
- Reviewed against the current default branch (after merging #250 and #251).
- Static/content review: confirmed no other learner-facing references to the removed VM size, resource group name, or hosting-platform terms remain in these five files.
- The retired-VM-size fix mirrors the exact replacement (`Standard_D2s_v5`) that a reporter on #252 confirmed worked successfully in their environment.
- Live environment retest of the corrected VM creation and Microsoft Entra ID sign-in flow in Lab 10 (Task 1 through Task 5) could not be completed in this session due to an automation tooling limitation unrelated to the lab content, and is flagged for a follow-up retest.

## Next step
Ready for review and merge. Recommend a follow-up MCT/live retest of Lab 10's VM creation and Microsoft Entra ID login flow (Tasks 1-5) to confirm the corrected VM size and resource group wording resolve #222 and #187/#252 end-to-end.
