### PR TITLE
Remove remaining lab-hoster-specific wording from Lab 10 and Lab 18

### DIFF
--- a/Instructions/Labs/Lab_10_AzureADAuthenticationForWindowsAndLinuxVM.md
+++ b/Instructions/Labs/Lab_10_AzureADAuthenticationForWindowsAndLinuxVM.md
@@ -145,7 +145,7 @@ The company has decided that Microsoft Entra ID should be used to login to virtu
 
 1. In the login dialog enter the following information:
    - Username = `AzureAD\User2@<your domain name>`
-   - Password = Enter the password provided by your lab provider
+   - Password = Enter the password provided for User2
 
     >**Note:** User2 is the user we granted access to log in as administrator during Task 1.
 

--- a/Instructions/Labs/Lab_18_DefenderForCloudAppsAccessPolicies.md
+++ b/Instructions/Labs/Lab_18_DefenderForCloudAppsAccessPolicies.md
@@ -35,8 +35,8 @@ Microsoft Defender for Cloud Apps  allows us to create additional Conditional Ac
 
 1. Sign in as **Pradeep Gupta**.
 
-   - **Username**: `PradeepG@<your lab hoster–provided domain>`
-   - **Password**: Use the password from the **Resources** tab.
+   - **Username**: `PradeepG@<the domain provided for this lab>`
+   - **Password**: Use the password provided for Pradeep Gupta.
 
 1. Confirm that Microsoft Forms opens and that no warning messages are displayed.
 
@@ -82,8 +82,8 @@ Microsoft Defender for Cloud Apps  allows us to create additional Conditional Ac
 
 1. Sign in as **Pradeep Gupta**.
 
-   - **Username**: `PradeepG@<your lab hoster–provided domain>`
-   - **Password**: Use the password from the **Resources** tab.
+   - **Username**: `PradeepG@<the domain provided for this lab>`
+   - **Password**: Use the password provided for Pradeep Gupta.
 
 1. Confirm that Pradeep has access and that the following message is displayed:
    - *Your company is monitoring the usage of this application.*
@@ -134,9 +134,9 @@ Registering your application establishes a trust relationship between your app a
 
 1. Sign in as **Pradeep Gupta**:
 
-   - **Username**: `PradeepG@<lab-hoster-domain>`
+   - **Username**: `PradeepG@<the domain provided for this lab>`
 
-   - **Password**: From the **Resources** tab.
+   - **Password**: Use the password provided for Pradeep Gupta.
 
 1. Confirm that Pradeep can access the service and that a message is displayed indicating company monitoring or usage of the application.
 


### PR DESCRIPTION
## Summary
This follow-up PR removes three more instances of lab-hosting-platform-specific wording that were missed in the first sweep (they were split across Markdown bold tags, e.g. "the **Resources** tab", so they didn't show up in a plain-text search initially): two in Lab 18 and one in Lab 10.

## Learner/instructor impact
These steps referred to "your lab hoster" and "the Resources tab" — concepts that only make sense on one specific lab-hosting platform's UI. Since this course is delivered through more than one lab-hosting platform, instructions like this are confusing or meaningless to learners on a different platform.

## What changed and why
Reworded all three instances to describe what the learner needs (the account/password provided for the lab) without naming a specific hosting platform or UI element, consistent with the host-agnostic wording already applied to Labs 01, 07, 23, and 27 in the previous PR (#254).

## Validation
Reviewed against the current default branch. Re-ran a repository-wide search for "hoster" and for "Resources" split across bold tags; no further instances remain in `Instructions/Labs/`.

## Next step
Ready for review and merge.
